### PR TITLE
feat: add configurable ZkResponsePolicy for ZK proof failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,33 @@ is TransferEvent.RequestReceived -> {
 }
 ```
 
+### Zero-Knowledge Proof Support
+
+The library supports Zero-Knowledge Proof (ZKP) systems for selective disclosure. When configured,
+the wallet can generate ZK proofs instead of disclosing raw document data, providing enhanced privacy.
+
+To enable ZKP support, provide a `ZkSystemRepository` and optionally configure the `ZkResponsePolicy`:
+
+```kotlin
+val transferManager = TransferManager.getDefault(
+    context = context,
+    documentManager = documentManager,
+    zkSystemRepository = zkSystemRepository,
+    zkResponsePolicy = ZkResponsePolicy.Strict,
+)
+```
+
+The `ZkResponsePolicy` determines behavior when ZK proof generation fails:
+
+| Policy | Behavior |
+|--------|----------|
+| `ZkResponsePolicy.Strict` | Aborts disclosure for the document. **Recommended for production.** |
+| `ZkResponsePolicy.FallbackToFullDisclosure` | Falls back to sending the full document. Current default for backwards compatibility. |
+
+> **Note:** The default policy is `FallbackToFullDisclosure` for backwards compatibility. This will
+> change to `Strict` in a future release. We recommend explicitly setting `ZkResponsePolicy.Strict`
+> in production to prevent unintended full document disclosure when proof generation fails.
+
 ## How to contribute
 
 We welcome contributions to this project. To ensure that the process is smooth for everyone

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManager.kt
@@ -22,6 +22,7 @@ import eu.europa.ec.eudi.iso18013.transfer.engagement.NfcEngagementService
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.Response
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 
@@ -93,6 +94,9 @@ interface TransferManager : TransferEvent.Listenable {
          * @param readerTrustStore
          * @param retrievalMethods
          * @param zkSystemRepository
+         * @param zkResponsePolicy the ZK response policy to use when ZK proof generation fails.
+         * Defaults to [ZkResponsePolicy.FallbackToFullDisclosure] for backwards compatibility.
+         * Consider using [ZkResponsePolicy.Strict] for production to prevent unintended full disclosure.
          * @return a [TransferManagerImpl]
          */
         @JvmStatic
@@ -101,12 +105,14 @@ interface TransferManager : TransferEvent.Listenable {
             documentManager: DocumentManager,
             readerTrustStore: ReaderTrustStore? = null,
             retrievalMethods: List<DeviceRetrievalMethod>? = null,
-            zkSystemRepository: ZkSystemRepository? = null
+            zkSystemRepository: ZkSystemRepository? = null,
+            zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
         ): TransferManager = TransferManagerImpl(context) {
             documentManager(documentManager)
             readerTrustStore?.let { readerTrustStore(it) }
             retrievalMethods?.let { retrievalMethods(it) }
             zkSystemRepository?.let { zkSystemRepository(it) }
+            zkResponsePolicy(zkResponsePolicy)
         }
     }
 }

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImpl.kt
@@ -36,6 +36,7 @@ import eu.europa.ec.eudi.iso18013.transfer.response.Response
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequest
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceResponse
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import org.multipaz.mdoc.origininfo.OriginInfo
 import org.multipaz.mdoc.origininfo.OriginInfoDomain
@@ -399,6 +400,7 @@ class TransferManagerImpl @JvmOverloads constructor(
      * @property readerTrustStore reader trust store instance
      * @property retrievalMethods list of device retrieval methods
      * @property zkSystemRepository ZK system repository instance
+     * @property zkResponsePolicy ZK response policy
      * @constructor
      * @param context
      */
@@ -408,6 +410,7 @@ class TransferManagerImpl @JvmOverloads constructor(
         var readerTrustStore: ReaderTrustStore? = null
         var retrievalMethods: List<DeviceRetrievalMethod>? = null
         var zkSystemRepository: ZkSystemRepository? = null
+        var zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
 
         /**
          * Document manager instance that will be used to retrieve the requested documents
@@ -441,6 +444,16 @@ class TransferManagerImpl @JvmOverloads constructor(
         }
 
         /**
+         * ZK response policy that determines behavior when ZK proof generation fails.
+         * Defaults to [ZkResponsePolicy.FallbackToFullDisclosure] for backwards compatibility.
+         * Consider using [ZkResponsePolicy.Strict] for production to prevent unintended full disclosure.
+         * @param zkResponsePolicy
+         */
+        fun zkResponsePolicy(zkResponsePolicy: ZkResponsePolicy) = apply {
+            this.zkResponsePolicy = zkResponsePolicy
+        }
+
+        /**
          * Build a [eu.europa.ec.eudi.iso18013.transfer.TransferManagerImpl] instance
          * with [DeviceRequestProcessor] instance
          * @return [eu.europa.ec.eudi.iso18013.transfer.TransferManagerImpl]
@@ -452,7 +465,8 @@ class TransferManagerImpl @JvmOverloads constructor(
                 requestProcessor = DeviceRequestProcessor(
                     documentManager = documentManager!!,
                     readerTrustStore = readerTrustStore,
-                    zkSystemRepository = zkSystemRepository
+                    zkSystemRepository = zkSystemRepository,
+                    zkResponsePolicy = zkResponsePolicy
                 ),
                 retrievalMethods = retrievalMethods ?: emptyList()
             )

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessor.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocuments
 import eu.europa.ec.eudi.iso18013.transfer.zkp.MatchedZkSystem
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.iso18013.transfer.zkp.findMatchedZkSystem
 import eu.europa.ec.eudi.wallet.document.DocType
 import eu.europa.ec.eudi.wallet.document.DocumentManager
@@ -43,11 +44,13 @@ import org.multipaz.mdoc.request.DeviceRequest as MultipazDeviceRequest
  * @property documentManager the document manager to retrieve the requested documents
  * @property readerTrustStore the reader trust store to perform reader authentication
  * @property zkSystemRepository the zero-knowledge proof system repository
+ * @property zkResponsePolicy the ZK response policy to use when ZK proof generation fails
  */
 class DeviceRequestProcessor(
     private val documentManager: DocumentManager,
     override var readerTrustStore: ReaderTrustStore? = null,
-    private var zkSystemRepository: ZkSystemRepository? = null
+    private var zkSystemRepository: ZkSystemRepository? = null,
+    internal val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
 ) : RequestProcessor, ReaderTrustStoreAware {
 
     /**
@@ -93,7 +96,8 @@ class DeviceRequestProcessor(
             return ProcessedDeviceRequest(
                 documentManager = documentManager,
                 requestedDocuments = requestedDocuments,
-                sessionTranscript = request.sessionTranscriptBytes
+                sessionTranscript = request.sessionTranscriptBytes,
+                zkResponsePolicy = zkResponsePolicy
             )
         } catch (e: Throwable) {
             return RequestProcessor.ProcessedRequest.Failure(e)

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/response/device/ProcessedDeviceRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import eu.europa.ec.eudi.iso18013.transfer.response.DisclosedDocuments
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocuments
 import eu.europa.ec.eudi.iso18013.transfer.response.ResponseResult
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.eudi.wallet.document.DocumentManager
 import kotlinx.coroutines.runBlocking
@@ -40,11 +41,13 @@ import kotlin.time.ExperimentalTime
  * @property sessionTranscript the session transcript
  * @property requestedDocuments the requested documents
  * @property includeOnlyRequested whether to include only the requested documents or all the disclosed documents. Default is true.
+ * @property zkResponsePolicy the policy to use when ZK proof generation fails. Default is [ZkResponsePolicy.FallbackToFullDisclosure].
  */
 class ProcessedDeviceRequest(
     private val documentManager: DocumentManager,
     private val sessionTranscript: ByteArray,
-    requestedDocuments: RequestedDocuments
+    requestedDocuments: RequestedDocuments,
+    private val zkResponsePolicy: ZkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
 ) : RequestProcessor.ProcessedRequest.Success(requestedDocuments) {
 
     var includeOnlyRequested: Boolean = true
@@ -90,18 +93,29 @@ class ProcessedDeviceRequest(
                         // No matched ZK system, add encoded document
                         deviceResponseGenerator.addDocument(encodedDocument)
                     } else {
-                        // Matched ZK system found, try to generate ZK proof
-                        runCatching {
-                            matchedZkSystem.system.generateProof(
-                                zkSystemSpec = matchedZkSystem.spec,
-                                encodedDocument = ByteString(encodedDocument),
-                                encodedSessionTranscript = ByteString(sessionTranscript)
-                            )
-                        }.onSuccess { zkDocument ->
-                            deviceResponseGenerator.addZkDocument(zkDocument)
-                        }.onFailure {
-                            // Fallback to encoded document if ZK proof generation fails
-                            deviceResponseGenerator.addDocument(encodedDocument)
+                        when (zkResponsePolicy) {
+                            ZkResponsePolicy.Strict -> {
+                                val zkDocument = matchedZkSystem.system.generateProof(
+                                    zkSystemSpec = matchedZkSystem.spec,
+                                    encodedDocument = ByteString(encodedDocument),
+                                    encodedSessionTranscript = ByteString(sessionTranscript)
+                                )
+                                deviceResponseGenerator.addZkDocument(zkDocument)
+                            }
+
+                            ZkResponsePolicy.FallbackToFullDisclosure -> {
+                                runCatching {
+                                    matchedZkSystem.system.generateProof(
+                                        zkSystemSpec = matchedZkSystem.spec,
+                                        encodedDocument = ByteString(encodedDocument),
+                                        encodedSessionTranscript = ByteString(sessionTranscript)
+                                    )
+                                }.onSuccess { zkDocument ->
+                                    deviceResponseGenerator.addZkDocument(zkDocument)
+                                }.onFailure {
+                                    deviceResponseGenerator.addDocument(encodedDocument)
+                                }
+                            }
                         }
                     }
                     documentIds.add(disclosedDocument.documentId)

--- a/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/zkp/ZkResponsePolicy.kt
+++ b/transfer-manager/src/main/java/eu/europa/ec/eudi/iso18013/transfer/zkp/ZkResponsePolicy.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.europa.ec.eudi.iso18013.transfer.zkp
+
+/**
+ * Policy that determines behavior when ZK proof generation fails during response generation.
+ */
+sealed interface ZkResponsePolicy {
+
+    /**
+     * Abort disclosure for the document if ZK proof generation fails.
+     * Recommended for production use to prevent unintended full document disclosure.
+     */
+    data object Strict : ZkResponsePolicy
+
+    /**
+     * Fall back to full document disclosure if ZK proof generation fails.
+     * This is the current default for backwards compatibility and will be changed
+     * to [Strict] in a future release.
+     */
+    data object FallbackToFullDisclosure : ZkResponsePolicy
+}

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplBuilderTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/TransferManagerImplBuilderTest.kt
@@ -20,9 +20,8 @@ import android.util.Log
 import eu.europa.ec.eudi.iso18013.transfer.engagement.DeviceRetrievalMethod
 import eu.europa.ec.eudi.iso18013.transfer.readerauth.ReaderTrustStore
 import eu.europa.ec.eudi.iso18013.transfer.response.device.DeviceRequestProcessor
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import io.mockk.mockk
-import org.junit.After
-import org.junit.Before
 import org.mockito.MockedStatic
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -76,6 +75,20 @@ class TransferManagerImplBuilderTest {
         assertNotNull(transferManager)
         assertIs<DeviceRequestProcessor>(transferManager.requestProcessor)
         assertEquals(retrievalMethods, transferManager.retrievalMethods)
+    }
+
+    @Test
+    fun buildTransferManagerWithDefaultZkResponsePolicy() {
+        val transferManager = TransferManagerImpl.Builder(Context)
+            .documentManager(createDocumentManager(null))
+            .build()
+
+        assertNotNull(transferManager)
+        assertIs<DeviceRequestProcessor>(transferManager.requestProcessor)
+        assertEquals(
+            ZkResponsePolicy.FallbackToFullDisclosure,
+            (transferManager.requestProcessor as DeviceRequestProcessor).zkResponsePolicy
+        )
     }
 
     @Test

--- a/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessorTest.kt
+++ b/transfer-manager/src/test/java/eu/europa/ec/eudi/iso18013/transfer/response/device/DeviceRequestProcessorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 European Commission
+ * Copyright (c) 2024-2026 European Commission
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,24 +25,29 @@ import eu.europa.ec.eudi.iso18013.transfer.response.DisclosedDocument
 import eu.europa.ec.eudi.iso18013.transfer.response.DisclosedDocuments
 import eu.europa.ec.eudi.iso18013.transfer.response.Request
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestProcessor.ProcessedRequest.Failure
+import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
+import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocuments
 import eu.europa.ec.eudi.iso18013.transfer.response.ResponseResult
 import eu.europa.ec.eudi.iso18013.transfer.toDocItems
+import eu.europa.ec.eudi.iso18013.transfer.zkp.MatchedZkSystem
+import eu.europa.ec.eudi.iso18013.transfer.zkp.ZkResponsePolicy
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocData
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocFormat
+import io.mockk.every
 import io.mockk.mockk
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 import org.mockito.MockedStatic
 import org.multipaz.crypto.Algorithm
+import org.multipaz.mdoc.zkp.ZkSystem
+import org.multipaz.mdoc.zkp.ZkSystemSpec
 import org.multipaz.securearea.KeyLockedException
 import org.multipaz.securearea.software.SoftwareKeyUnlockData
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.time.ExperimentalTime
 
 class DeviceRequestProcessorTest {
     lateinit var mockLog: MockedStatic<Log>
@@ -172,5 +177,110 @@ class DeviceRequestProcessorTest {
         assertIs<ResponseResult.Success>(responseResult)
         assertIs<DeviceResponse>(responseResult.response)
 
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `processed request should return failure when ZK proof generation fails`() {
+        val documentManager = createDocumentManager(null)
+        val requestProcessor = DeviceRequestProcessor(documentManager)
+        val expectedDocument = documentManager.getDocuments()
+            .filterIsInstance<IssuedDocument>()
+            .first { it.format is MsoMdocFormat && (it.format as MsoMdocFormat).docType == "org.iso.18013.5.1.mDL" }
+        val processedRequest = requestProcessor.process(DeviceRequest)
+        assertIs<ProcessedDeviceRequest>(processedRequest)
+        val documentData = expectedDocument.data
+        assertIs<MsoMdocData>(documentData)
+
+        // Create a matched ZK system that throws on generateProof
+        val failingZkSystem = mockk<ZkSystem> {
+            every { generateProof(any(), any(), any()) } throws RuntimeException("ZK proof generation failed")
+        }
+        val zkSystemSpec = mockk<ZkSystemSpec>()
+        val matchedZkSystem = MatchedZkSystem(failingZkSystem, zkSystemSpec)
+
+        // Rebuild requestedDocuments with the failing matchedZkSystem
+        val requestedDocumentsWithZk = RequestedDocuments(
+            processedRequest.requestedDocuments.map { reqDoc ->
+                RequestedDocument(
+                    documentId = reqDoc.documentId,
+                    requestedItems = reqDoc.requestedItems,
+                    readerAuth = reqDoc.readerAuth,
+                    matchedZkSystem = matchedZkSystem
+                )
+            }
+        )
+
+        val processedRequestWithZk = ProcessedDeviceRequest(
+            documentManager = documentManager,
+            sessionTranscript = DeviceRequest.sessionTranscriptBytes,
+            requestedDocuments = requestedDocumentsWithZk,
+            zkResponsePolicy = ZkResponsePolicy.Strict
+        )
+
+        val responseResult = processedRequestWithZk.generateResponse(
+            disclosedDocuments = DisclosedDocuments(
+                DisclosedDocument(
+                    documentId = expectedDocument.id,
+                    disclosedItems = documentData.nameSpaces.toDocItems(),
+                )
+            ),
+            signatureAlgorithm = Algorithm.ES256,
+        )
+
+        // ZK proof failure must NOT silently fall back to full disclosure
+        assertIs<ResponseResult.Failure>(responseResult)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun `processed request should return success with fallback policy when ZK proof generation fails`() {
+        val documentManager = createDocumentManager(null)
+        val requestProcessor = DeviceRequestProcessor(documentManager)
+        val expectedDocument = documentManager.getDocuments()
+            .filterIsInstance<IssuedDocument>()
+            .first { it.format is MsoMdocFormat && (it.format as MsoMdocFormat).docType == "org.iso.18013.5.1.mDL" }
+        val processedRequest = requestProcessor.process(DeviceRequest)
+        assertIs<ProcessedDeviceRequest>(processedRequest)
+        val documentData = expectedDocument.data
+        assertIs<MsoMdocData>(documentData)
+
+        val failingZkSystem = mockk<ZkSystem> {
+            every { generateProof(any(), any(), any()) } throws RuntimeException("ZK proof generation failed")
+        }
+        val zkSystemSpec = mockk<ZkSystemSpec>()
+        val matchedZkSystem = MatchedZkSystem(failingZkSystem, zkSystemSpec)
+
+        val requestedDocumentsWithZk = RequestedDocuments(
+            processedRequest.requestedDocuments.map { reqDoc ->
+                RequestedDocument(
+                    documentId = reqDoc.documentId,
+                    requestedItems = reqDoc.requestedItems,
+                    readerAuth = reqDoc.readerAuth,
+                    matchedZkSystem = matchedZkSystem
+                )
+            }
+        )
+
+        val processedRequestWithZk = ProcessedDeviceRequest(
+            documentManager = documentManager,
+            sessionTranscript = DeviceRequest.sessionTranscriptBytes,
+            requestedDocuments = requestedDocumentsWithZk,
+            zkResponsePolicy = ZkResponsePolicy.FallbackToFullDisclosure
+        )
+
+        val responseResult = processedRequestWithZk.generateResponse(
+            disclosedDocuments = DisclosedDocuments(
+                DisclosedDocument(
+                    documentId = expectedDocument.id,
+                    disclosedItems = documentData.nameSpaces.toDocItems(),
+                )
+            ),
+            signatureAlgorithm = Algorithm.ES256,
+        )
+
+        // FallbackToFullDisclosure should return success even when ZK proof fails
+        assertIs<ResponseResult.Success>(responseResult)
+        assertIs<DeviceResponse>(responseResult.response)
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `ZkResponsePolicy` sealed interface with two variants:
  - `Strict`: aborts disclosure on ZK proof failure, returning `ResponseResult.Failure`
  - `FallbackToFullDisclosure`: falls back to full document disclosure (current default for backwards compatibility)
- Policy is constructor-injected through `TransferManager.Builder` -> `DeviceRequestProcessor` -> `ProcessedDeviceRequest`
- Default is `FallbackToFullDisclosure` for backwards compatibility; will change to `Strict` in a future release
- Adds "Zero-Knowledge Proof Support" section to README

## Test plan

- [x] Test: `Strict` policy + ZK proof failure returns `ResponseResult.Failure`
- [x] Test: `FallbackToFullDisclosure` policy + ZK proof failure returns `ResponseResult.Success`
- [x] Test: Builder default policy is `FallbackToFullDisclosure`
- [x] All existing tests pass unchanged